### PR TITLE
Add Python Docstrings to C++ bindings

### DIFF
--- a/Code/PythonBoost/python_docstrings.h
+++ b/Code/PythonBoost/python_docstrings.h
@@ -17,6 +17,18 @@
 
 using namespace std;
 
+/* Docstrings should use C++ string literals, for easier multi line comments.
+Equal indentations on each line, for Sphinx compatiblity. See
+(https://pybind11.readthedocs.io/en/stable/advanced/misc.html#generating-documentation-using-sphinx)
+*/
+
+auto example_docstring = R"(
+    this is a docstring.
+    :param input: var
+    :type input: float
+
+    )";
+
 auto icp_docstring = R"(
     Run Iterative Closest Point algorithm.
 

--- a/Code/PythonBoost/python_docstrings.h
+++ b/Code/PythonBoost/python_docstrings.h
@@ -17,17 +17,17 @@
 
 using namespace std;
 
-auto icp_docstring = R"mydelimiter(
+auto icp_docstring = R"(
     Run Iterative Closest Point algorithm.
-    
+
     :param source: Source pointcloud
     :type source: np.ndarray
     :param target: Target point cloud
     :type target: np.ndarray
     :return: 4x4 Transform matrix
-    )mydelimiter";
+    )";
 
-auto downsample_docstring = R"mydelimiter(
+auto downsample_docstring = R"(
     Downsample point cloud.
 
     :param input: Input pointcloud
@@ -40,9 +40,9 @@ auto downsample_docstring = R"mydelimiter(
     :type vz: float
     :return: Modified point cloud
     :rtype: np.ndarray
-    )mydelimiter";
+    )";
 
-auto remove_outlier_docstring = R"mydelimiter(
+auto remove_outlier_docstring = R"(
     Remove outliers from point cloud.
 
     :param input: Input pointcloud
@@ -53,6 +53,6 @@ auto remove_outlier_docstring = R"mydelimiter(
     mean +/- stdDev are considred outliers.
     :return: Output pointcloud
     :rtype: np.darray
-    )mydelimiter";
+    )";
 
 #endif

--- a/Code/PythonBoost/python_docstrings.h
+++ b/Code/PythonBoost/python_docstrings.h
@@ -1,0 +1,56 @@
+/*=============================================================================
+
+  SKSURGERYPCLCPP: Image-guided surgery functions, in C++, using PCL.
+
+  Copyright (c) University College London (UCL). All rights reserved.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+  See LICENSE.txt in the top level directory for details.
+
+=============================================================================*/
+
+#ifndef DOCSTRINGS_H
+#define DOCSTRINGS_H
+
+using namespace std;
+
+auto icp_docstring = R"(
+    Run Iterative Closest Point algorithm.
+
+    :param source: Source pointcloud
+    :type source: np.ndarray
+    :param target: Target point cloud
+    :type target: np.ndarray
+    :return: 4x4 Transform matrix
+    )";
+
+auto downsample_docstring = R"(
+    Downsample point cloud.
+    :param input: Input pointcloud
+    :type input: np.ndarray
+    :param vx: X  voxel size (metres)
+    :type vx: float
+    :param vy: Y voxel size (metres)
+    :type vy: float
+    :param vz: Z voxel size (metres)
+    :type vz: float
+    :return: Modified point cloud
+    :rtype: np.ndarray
+    )";
+
+auto remove_outlier_docstring = R"(
+    Remove outliers from point cloud.
+    :param input: Input pointcloud
+    :type input: np.ndarray
+    :param meanK: Number of points to use for mean distance estimation
+    :type meanK: float
+    :param stdDev: Standard deviation multiplier thershold. All points outside
+    mean +/- stdDev are considred outliers.
+    :return: Output pointcloud
+    :rtype: np.darray
+    )";
+
+#endif

--- a/Code/PythonBoost/python_docstrings.h
+++ b/Code/PythonBoost/python_docstrings.h
@@ -17,18 +17,19 @@
 
 using namespace std;
 
-auto icp_docstring = R"(
+auto icp_docstring = R"mydelimiter(
     Run Iterative Closest Point algorithm.
-
+    
     :param source: Source pointcloud
     :type source: np.ndarray
     :param target: Target point cloud
     :type target: np.ndarray
     :return: 4x4 Transform matrix
-    )";
+    )mydelimiter";
 
-auto downsample_docstring = R"(
+auto downsample_docstring = R"mydelimiter(
     Downsample point cloud.
+
     :param input: Input pointcloud
     :type input: np.ndarray
     :param vx: X  voxel size (metres)
@@ -39,10 +40,11 @@ auto downsample_docstring = R"(
     :type vz: float
     :return: Modified point cloud
     :rtype: np.ndarray
-    )";
+    )mydelimiter";
 
-auto remove_outlier_docstring = R"(
+auto remove_outlier_docstring = R"mydelimiter(
     Remove outliers from point cloud.
+
     :param input: Input pointcloud
     :type input: np.ndarray
     :param meanK: Number of points to use for mean distance estimation
@@ -51,6 +53,6 @@ auto remove_outlier_docstring = R"(
     mean +/- stdDev are considred outliers.
     :return: Output pointcloud
     :rtype: np.darray
-    )";
+    )mydelimiter";
 
 #endif

--- a/Code/PythonBoost/sksLibPython.cpp
+++ b/Code/PythonBoost/sksLibPython.cpp
@@ -18,6 +18,7 @@
 #include "sksDownSamplePointsWrapper.h"
 #include "sksRemoveOutlierPointsWrapper.h"
 #include "sksException.h"
+#include "python_docstrings.h"
 
 #include <ostream>
 #include <sstream>
@@ -38,9 +39,9 @@ BOOST_PYTHON_MODULE(sksurgerypclpython)
 {
   boost::python::numpy::initialize();
   boost::python::register_exception_translator<Exception>(&translate_exception);
-  boost::python::def("iterative_closest_point", sks::IterativeClosestPointWrapper);
-  boost::python::def("down_sample_points", sks::DownSamplePointsWrapper);
-  boost::python::def("remove_outlier_points", sks::RemoveOutlierPointsWrapper);
+  boost::python::def("iterative_closest_point", sks::IterativeClosestPointWrapper, icp_docstring);
+  boost::python::def("down_sample_points", sks::DownSamplePointsWrapper, downsample_docstring);
+  boost::python::def("remove_outlier_points", sks::RemoveOutlierPointsWrapper, remove_outlier_docstring);
 }
 
 }  // end namespace sks


### PR DESCRIPTION
Added docstrings for Python bindings. The same format can be used for other repos. I will add an example to CMakeCatchTemplate.

Next step is to get ReadTheDocs setup, but I tried it and it doesn't seem entirely straightforward.